### PR TITLE
Docs for setting up haskell-language-server & your favorite editor

### DIFF
--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -16,7 +16,7 @@ _This guide assumes that you've completed the steps described in [Prerequisites]
    ```
 6. Close the editor and re-open it in the project folder
    ```bash
-   cd <your-projects-dir>/plutus-pioneer-program/code/week02
+   cd <your-projects-dir>
    emacs .
    ```
    _Note: if you're using `nix-shell`, make sure to run it first._

--- a/docs/editors/emacs.md
+++ b/docs/editors/emacs.md
@@ -1,0 +1,24 @@
+# Emacs
+
+_This guide assumes that you've completed the steps described in [Prerequisites](./prerequisites.md)._
+
+1. If you're using `nix-shell`, make sure you launch your editor from the command line so it can inherit `$PATH`
+2. Install `haskell-mode` via `M-x RET package-install RET haskell-mode RET`
+3. Install `lsp-mode` via `M-x RET package-install RET lsp-mode RET`
+4. Install `lsp-haskell` via `M-x RET package-install RET lsp-haskell RET`
+5. Edit your `.emacs` file
+   ```elisp
+   (require 'lsp)
+   (require 'lsp-haskell)
+   ;; Hooks so haskell and literate haskell major modes trigger LSP setup
+   (add-hook 'haskell-mode-hook #'lsp)
+   (add-hook 'haskell-literate-mode-hook #'lsp)
+   ```
+6. Close the editor and re-open it in the project folder
+   ```bash
+   cd <your-projects-dir>/plutus-pioneer-program/code/week02
+   emacs .
+   ```
+   _Note: if you're using `nix-shell`, make sure to run it first._
+
+If everything is fine you should get auto-completion and other features working 🎉

--- a/docs/editors/prerequisites.md
+++ b/docs/editors/prerequisites.md
@@ -1,0 +1,47 @@
+# Prerequisites
+
+In order to setup your favorite editor for Haskell/Plutus development you need following components
+- GHC (haskell compiler) & cabal (build system for haskell projects)
+- [haskell-language-server](https://github.com/haskell/haskell-language-server/)
+
+## GHC & cabal
+You have 2 options for setting up the compiler infrastructure:
+- _Using Nix and nix-shell_. Assuming you've done setup of [plutus](https://github.com/input-output-hk/plutus) for running `plutus-playground` locally, you already have `ghc` and `cabal` binaries available inside `nix-shell`. 
+- _System-wide installation_. Generally, if you don't want to run `plutus-playground` locally and only want to compile Plutus contracts, you can use your existing haskell installation or install the compiler toolchain without Nix. For using this method, follow the instructions on [ghcup website](https://www.haskell.org/ghcup/).
+
+## HSL (haskell-language-server)
+IDE-like features like auto-completion, type hints, docs and jump-to-definition are provided by a tool called [haskell-language-server](https://github.com/haskell/haskell-language-server/). It is a standalone program that implements [Language Server Protocol (LSP)](https://langserver.org/) for Haskell. Your editor can talk to this program and get the information for showing types, doing auto-completion, etc.
+
+### Linux
+On Linux, installing the HSL is pretty straightforwad. If you've done Nix setup then you already have `haskell-language-server` binary on your `$PATH` inside `nix-shell`. 
+If you've done installation with `ghcup`, you can install HSL with following command
+```bash
+ghcup install hsl
+```
+or you can download pre-built binary from [releases page](https://github.com/haskell/haskell-language-server/releases). Don't forget to put the binary on your `$PATH`. 
+
+### macOS
+On macOS, the installation is a bit trickier. 
+Due to [linking proglems](https://github.com/haskell/haskell-language-server/issues/1160) HSL crashes when your project uses TemplateHaskell (which Plutus uses a lot) ([issue](https://github.com/haskell/haskell-language-server/issues/1431), [issue](https://github.com/haskell/haskell-language-server/issues/277)). The workaround for this is to compile HSL manually with dynamic linking support. 
+
+1. Make sure you have ghc & cabal installed and available on your `$PATH` (either locally or within `nix-shell`)
+2. Clone HSL repo
+```bash
+$ git clone https://github.com/haskell/haskell-language-server --recurse-submodules
+$ cd haskell-language-server
+```
+3. Make changes to `haskell-language-server.cabal` file to use dynamic linking (huge shoutout to `f` for finding that). The [diff](https://github.com/haskell/haskell-language-server/issues/1160#issuecomment-756566273)
+4. Find out your ghc version
+```bash
+ghc --version
+# The Glorious Glasgow Haskell Compilation System, version 8.10.4
+```
+5. Build HSL for your compiler version
+```bash
+./cabal-hls-install hls-<version>
+# cabal-hls-install hls-8.10.4
+```
+6. Once the build is done, newly created binary will be located in `$HOME/.cabal/bin`. If you use `nix-shell`, make sure that you use right binary since nix-shell provides its own. 
+
+
+Once you have everything set up you can proceed to configuring your editor.

--- a/docs/editors/prerequisites.md
+++ b/docs/editors/prerequisites.md
@@ -1,5 +1,9 @@
 # Prerequisites
 
+### Credits
+- https://github.com/tmphey
+- @nymeron#8182
+
 In order to setup your favorite editor for Haskell/Plutus development you need following components
 - GHC (haskell compiler) & cabal (build system for haskell projects)
 - [haskell-language-server](https://github.com/haskell/haskell-language-server/)
@@ -30,7 +34,7 @@ Due to [linking proglems](https://github.com/haskell/haskell-language-server/iss
    $ git clone https://github.com/haskell/haskell-language-server --recurse-submodules
    $ cd haskell-language-server
    ```
-3. Make changes to `haskell-language-server.cabal` file to use dynamic linking (huge shoutout to `f` for finding that). The [diff](https://github.com/haskell/haskell-language-server/issues/1160#issuecomment-756566273)
+3. Make changes to `haskell-language-server.cabal` file to use dynamic linking (huge shoutout to `@nymeron#8182` for finding that). The [diff](https://github.com/haskell/haskell-language-server/issues/1160#issuecomment-756566273)
 4. Find out your ghc version
    ```bash
    ghc --version

--- a/docs/editors/prerequisites.md
+++ b/docs/editors/prerequisites.md
@@ -15,9 +15,9 @@ IDE-like features like auto-completion, type hints, docs and jump-to-definition 
 ### Linux
 On Linux, installing the HSL is pretty straightforwad. If you've done Nix setup then you already have `haskell-language-server` binary on your `$PATH` inside `nix-shell`. 
 If you've done installation with `ghcup`, you can install HSL with following command
-```bash
-ghcup install hsl
-```
+   ```bash
+   ghcup install hsl
+   ```
 or you can download pre-built binary from [releases page](https://github.com/haskell/haskell-language-server/releases). Don't forget to put the binary on your `$PATH`. 
 
 ### macOS
@@ -26,21 +26,21 @@ Due to [linking proglems](https://github.com/haskell/haskell-language-server/iss
 
 1. Make sure you have ghc & cabal installed and available on your `$PATH` (either locally or within `nix-shell`)
 2. Clone HSL repo
-```bash
-$ git clone https://github.com/haskell/haskell-language-server --recurse-submodules
-$ cd haskell-language-server
-```
+   ```bash
+   $ git clone https://github.com/haskell/haskell-language-server --recurse-submodules
+   $ cd haskell-language-server
+   ```
 3. Make changes to `haskell-language-server.cabal` file to use dynamic linking (huge shoutout to `f` for finding that). The [diff](https://github.com/haskell/haskell-language-server/issues/1160#issuecomment-756566273)
 4. Find out your ghc version
-```bash
-ghc --version
-# The Glorious Glasgow Haskell Compilation System, version 8.10.4
-```
+   ```bash
+   ghc --version
+   # The Glorious Glasgow Haskell Compilation System, version 8.10.4
+   ```
 5. Build HSL for your compiler version
-```bash
-./cabal-hls-install hls-<version>
-# cabal-hls-install hls-8.10.4
-```
+   ```bash
+   ./cabal-hls-install hls-<version>
+   # cabal-hls-install hls-8.10.4
+   ```
 6. Once the build is done, newly created binary will be located in `$HOME/.cabal/bin`. If you use `nix-shell`, make sure that you use right binary since nix-shell provides its own. 
 
 

--- a/docs/editors/sublime_text.md
+++ b/docs/editors/sublime_text.md
@@ -21,7 +21,7 @@ _This guide assumes that you've completed the steps described in [Prerequisites]
    ```
 4. Close the editor and re-open it in the project folder
    ```bash
-   cd <your-projects-dir>/plutus-pioneer-program/code/week02
+   cd <your-projects-dir>
    subl .
    ```
    _Note: if you're using `nix-shell`, make sure to run it first._

--- a/docs/editors/sublime_text.md
+++ b/docs/editors/sublime_text.md
@@ -1,0 +1,29 @@
+# Sublime Text
+
+_This guide assumes that you've completed the steps described in [Prerequisites](./prerequisites.md)._
+
+1. If you're using `nix-shell`, make sure you can launch the editor from the command line so it inherits your `$PATH`.
+   Follow the instructions [here](https://www.sublimetext.com/docs/command_line.html).
+2. Install LSP: Open the command palette and run `Package Control: Install Package`, then select `LSP`.
+3. Open LSP settings: `Preferences -> Package Settings -> LSP -> Settings` and add this
+   ```json
+   {
+    "clients": {
+        "haskell-language-server": {
+          "command": ["haskell-language-server", "--lsp"],
+          "scopes": ["source.haskell"],
+          "syntaxes": ["Packages/Haskell/Haskell.sublime-syntax"],
+          "languageId": "haskell",
+          "enabled": true
+        },
+    }
+   }
+   ```
+4. Close the editor and re-open it in the project folder
+   ```bash
+   cd <your-projects-dir>/plutus-pioneer-program/code/week02
+   subl .
+   ```
+   _Note: if you're using `nix-shell`, make sure to run it first._
+
+If everything is fine you should get auto-completion and other features working 🎉

--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -1,0 +1,16 @@
+# Visual Studio Code
+
+_This guide assumes that you've completed the steps described in [Prerequisites](./prerequisites.md)._
+
+1. If you're using `nix-shell`, make sure you can launch the editor from the command line so it inherits your `$PATH`.
+   On Linux, `code` command is automatically available after VSCode installation.
+   On macOS, follow the [instruction](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line)
+2. Install the [Haskell extension](https://marketplace.visualstudio.com/items?itemName=haskell.haskell)
+3. Close the editor and re-open it in the project folder
+   ```bash
+   cd <your-projects-dir>/plutus-pioneer-program/code/week02
+   code .
+   ```
+   _Note: if you're using `nix-shell`, make sure to run it first._
+
+If everything is fine you should get auto-completion and other features working 🎉

--- a/docs/editors/vscode.md
+++ b/docs/editors/vscode.md
@@ -8,7 +8,7 @@ _This guide assumes that you've completed the steps described in [Prerequisites]
 2. Install the [Haskell extension](https://marketplace.visualstudio.com/items?itemName=haskell.haskell)
 3. Close the editor and re-open it in the project folder
    ```bash
-   cd <your-projects-dir>/plutus-pioneer-program/code/week02
+   cd <your-projects-dir>
    code .
    ```
    _Note: if you're using `nix-shell`, make sure to run it first._


### PR DESCRIPTION
Hey folks!

Here are some instructions how you can setup IDE-like features (auto-completion, type hints, go-to-definition) for Haskell/Plutus development.

I've added instructions for Linux & macOS for following editors
- VSCode
- Sublime Text
- Emacs
Vim is missing here since i've never set up vim with LSP.

Also we're missing instructions for Windows.

Feedback appreciated! 