### PR TITLE
Editors Update - Adding additional troubleshooting steps for Visual Studio Code

### DIFF
--- a/book/docs/setup/editors/vscode.md
+++ b/book/docs/setup/editors/vscode.md
@@ -21,9 +21,20 @@ _This guide assumes that you've completed the steps described in [Prerequisites]
 If everything is fine you should get auto-completion and other features working 🎉
 
 ---
+</br>
 
 ### Additional Troubleshooting Steps
 _In the event the above steps result in the Visual Studio Code Editor not displaying definitions._
+
+### Tested with
+```
+Ubuntu                                          v20.x
+Windows                                         v10.x
+Nix                                             v2.3.10
+Visual Studio Code                              v1.55.2
+VSCode Extension Haskell                        v1.2.0
+VSCode Extension Haskell Syntax Highlighting    v3.4.0
+```
 
 ### How to Check
 _Select a function in the Visual Studio Code Editor and right click and choose **Go to Definition** or highlight a function and press **F12**_.
@@ -44,9 +55,9 @@ foo x y z =  readMaybe x `bindMaybe` \num1 ->
 ### Possible Solution
 1. Open the built-in terminal inside your Visual Studio Code by pressing `control` _+_ `~ ` at the same time or by going to `Terminal > New Terminal` within the file menu.
 
-2. From the built in terminal navigate to your **plutus** directory or clone a new copy of the [plutus repository](https://github.com/input-output-hk/plutus).
+2. From the built in terminal, navigate to your **plutus** directory or clone a new copy of the [plutus repository](https://github.com/input-output-hk/plutus).
 
-3. From the **plutus** root directory run the following command `nix-shell`. (_This command requires access to the `default.nix, shell.nix ` files that are part of every plutus repository fork or clone._)
+3. From the **plutus** root directory, run the following command `nix-shell`. (_This command requires access to the `default.nix, shell.nix ` files that are part of every plutus repository forks or clones._)
 
 `nix-shell Example: Should look something like this.`
 ```c

--- a/book/docs/setup/editors/vscode.md
+++ b/book/docs/setup/editors/vscode.md
@@ -3,6 +3,7 @@
 ### Credits
 - https://github.com/tmphey
 - @nymeron#8182
+- @getHashSet
 
 _This guide assumes that you've completed the steps described in [Prerequisites](./prerequisites.md)._
 
@@ -18,3 +19,48 @@ _This guide assumes that you've completed the steps described in [Prerequisites]
    _Note: if you're using `nix-shell`, make sure to run it first._
 
 If everything is fine you should get auto-completion and other features working 🎉
+
+---
+
+### Additional Troubleshooting Steps
+_In the event the above steps result in the Visual Studio Code Editor not displaying definitions._
+
+### How to Check
+_Select a function in the Visual Studio Code Editor and right click and choose **Go to Definition** or highlight a function and press **F12**_.
+
+`Example: bindMaybe displays the error No definition found for 'bindMabye' even though it is defined only a few lines up.`
+```
+bindMaybe :: Maybe a -> (a -> Maybe b) -> Maybe b
+bindMaybe Nothing _ = Nothing
+bindMaybe (Just x) f = f x
+
+foo :: String -> String -> String -> Maybe Int
+foo x y z =  readMaybe x `bindMaybe` \num1 ->
+             readMaybe y `bindMaybe` \num2 ->
+             readMaybe z `bindMaybe` \num3 ->
+             Just (num1 + num2 + num3)
+```
+
+### Possible Solution
+1. Open the built-in terminal inside your Visual Studio Code by pressing `control` _+_ `~ ` at the same time or by going to `Terminal > New Terminal` within the file menu.
+
+2. From the built in terminal navigate to your **plutus** directory or clone a new copy of the [plutus repository](https://github.com/input-output-hk/plutus).
+
+3. From the **plutus** root directory run the following command `nix-shell`. (_This command requires access to the `default.nix, shell.nix ` files that are part of every plutus repository fork or clone._)
+
+`nix-shell Example: Should look something like this.`
+```c
+[nix-shell:~/<your file path>/plutus-pioneer-program/code/week04]$ |
+```
+
+4. Once in the nix-shell instance navigate back to your **plutus-pioneer-program/code/weekxx/** folder and run `code .` (_Note: This will launch a new Visual Studio Code Window. It is now safe to close the prior Visual Studio Code instance._)
+
+5. :boom:
+
+Your Visual Studio Code instance should now have access to definitions. Test this by selecting a function an pressing **F12**.
+
+`Definition Example: When pressing F12 or while hovering the function name.`
+```haskell
+bindMaybe :: forall a b. Maybe a -> (a -> Maybe b) -> Maybe b
+Defined at /<your path>/plutus-pioneer-program/code/week04/src/Week04/Maybe.hs:19:1
+```

--- a/book/docs/setup/editors/vscode.md
+++ b/book/docs/setup/editors/vscode.md
@@ -21,7 +21,6 @@ _This guide assumes that you've completed the steps described in [Prerequisites]
 If everything is fine you should get auto-completion and other features working 🎉
 
 ---
-</br>
 
 ### Additional Troubleshooting Steps
 _In the event the above steps result in the Visual Studio Code Editor not displaying definitions._
@@ -37,7 +36,7 @@ VSCode Extension Haskell Syntax Highlighting    v3.4.0
 ```
 
 ### How to Check
-_Select a function in the Visual Studio Code Editor and right click and choose **Go to Definition** or highlight a function and press **F12**_.
+_Select a function in the Visual Studio Code Editor and right-click and choose **Go to Definition** or highlight a function and press **F12**_.
 
 `Example: bindMaybe displays the error No definition found for 'bindMabye' even though it is defined only a few lines up.`
 ```
@@ -55,7 +54,7 @@ foo x y z =  readMaybe x `bindMaybe` \num1 ->
 ### Possible Solution
 1. Open the built-in terminal inside your Visual Studio Code by pressing `control` _+_ `~ ` at the same time or by going to `Terminal > New Terminal` within the file menu.
 
-2. From the built in terminal, navigate to your **plutus** directory or clone a new copy of the [plutus repository](https://github.com/input-output-hk/plutus).
+2. From the built-in terminal, navigate to your **plutus** directory or clone a new copy of the [plutus repository](https://github.com/input-output-hk/plutus).
 
 3. From the **plutus** root directory, run the following command `nix-shell`. (_This command requires access to the `default.nix, shell.nix ` files that are part of every plutus repository forks or clones._)
 


### PR DESCRIPTION
Additional Troubleshooting steps added for Visual Studio Code users that are unable to grant $PATH access to their VSCode instances.

Additional steps to resolve include opening a new instance of VSCode through the built in terminal windows.

Added code examples and testing notes.