### PR TITLE
Haddock web

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -8,9 +8,9 @@
   * [Windows WSL2](/docs/setup/WindowsWSL.md)
   * [Ubuntu](/docs/setup/Ubuntu.md)
   * [MacOS including M1](/docs/setup/MacOS.md)
-  * [Local Plutus API documentation (Optional)](/docs/setup/buildDocumentation.md)
 ## Additional Configuration
   * [Cabal Build](/docs/setup/CabalBuild.md)
+  * [Local Plutus API documentation](/docs/setup/buildDocumentation.md)
 
 ## Editors
    * [Prerequisites](/docs/setup/editors/prerequisites.md)

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -8,7 +8,7 @@
   * [Windows WSL2](/docs/setup/WindowsWSL.md)
   * [Ubuntu](/docs/setup/Ubuntu.md)
   * [MacOS including M1](/docs/setup/MacOS.md)
-
+  * [Local Plutus API documentation (Optional)](/docs/setup/buildDocumentation.md)
 ## Additional Configuration
   * [Cabal Build](/docs/setup/CabalBuild.md)
 

--- a/book/docs/setup/Ubuntu.md
+++ b/book/docs/setup/Ubuntu.md
@@ -152,6 +152,26 @@ will complain about it being a risky website, allow it.
 
 ## Miscellaneous
 
+### Plutus Documentation
+
+Documentation is built automatically. You shoud see a symbolic link under `~/plutus` which looks like:
+
+```bash
+# the documentation folder includes the word haddock    -|
+result -> /nix/store/p9zqm03qmc7p5p1vfdbl06xysm85ir4f-haddock-join/
+```
+
+If this folder isn't in under `~/plutus` you can build it with 
+
+```bash
+[~/plutus] nix-build -A plutus-playground.haddock
+```
+
+You can see the plutus documentation in your regular browser. for example:
+
+```
+brave-browser ~/plutus/result/share/doc/index.html
+```
 
 ### Completely uninstalling Nix
 

--- a/book/docs/setup/Ubuntu.md
+++ b/book/docs/setup/Ubuntu.md
@@ -152,27 +152,6 @@ will complain about it being a risky website, allow it.
 
 ## Miscellaneous
 
-### Plutus Documentation
-
-Documentation is built automatically. You shoud see a symbolic link under `~/plutus` which looks like:
-
-```bash
-# the documentation folder includes the word haddock    -|
-result -> /nix/store/p9zqm03qmc7p5p1vfdbl06xysm85ir4f-haddock-join/
-```
-
-If this folder isn't in under `~/plutus` you can build it with 
-
-```bash
-[~/plutus] nix-build -A plutus-playground.haddock
-```
-
-You can see the plutus documentation in your regular browser. for example:
-
-```
-brave-browser ~/plutus/result/share/doc/index.html
-```
-
 ### Completely uninstalling Nix
 
 Nix (unfortunately) installs with a non-distro-specific and not-reversible

--- a/book/docs/setup/buildDocumentation.md
+++ b/book/docs/setup/buildDocumentation.md
@@ -1,0 +1,41 @@
+# Plutus API documentation
+
+## Local build
+
+If you've built Plutus with Nix, documentation you shoud be ready as a symbolic link under `~/plutus` folder. Look for the symbolic link which contains _haddock_<sup>1</sup>:
+
+```bash
+# the documentation folder includes the word haddock    -|
+result -> /nix/store/p9zqm03qmc7p5p1vfdbl06xysm85ir4f-haddock-join/
+```
+
+If this folder isn't under `~/plutus` you can build it with the command
+
+```bash
+[~/plutus] nix-build -A plutus-playground.haddock
+```
+
+You can see the plutus documentation in your regular browser. for example:
+
+```bash 
+brave-browser ~/plutus/result/share/doc/index.html
+```
+
+
+[^1]: haddock is haskell's tool for documentation generation
+
+
+## How to use the documentation
+
+The plutus documentation is a big static webpage and It includes many modules not directly related with Plutus Contracts, like Plutus Core, Plutus IR or the Playground backend. 
+
+The most interesting modules for contract coding can be found at the very top of index.html page. Those are:
+
+```
+PlutusTx: Compiling Haskell to PLC (Plutus Core; on-chain code).
+PlutusTx.Prelude: Haskell prelude replacement compatible with PLC.
+Plutus.Contract: Writing Plutus apps (off-chain code).
+Ledger.Constraints: Constructing and validating Plutus transactions. Built on PlutusTx and Plutus.Contract.
+Ledger.Typed.Scripts: A type-safe interface for spending and producing script outputs. Built on PlutusTx.
+Plutus.Trace.Emulator: Testing Plutus contracts in the emulator.
+```

--- a/book/docs/setup/buildDocumentation.md
+++ b/book/docs/setup/buildDocumentation.md
@@ -30,17 +30,22 @@ brave-browser ~/plutus/result/share/doc/index.html
 The method above will open the Plutus API documentation using `file://` procotol, which can lead to problems dealing with javascript, mainly haddock's search utility is disable. We can use plutus dependencies available within the `nix-shell` to effortless create a local static site web server to serve the documentation using `http` protocol.
 
 - Open a nix shell in plutus folder
+
 ```bash
 > cd path/to/plutus
 > nix-shell
 ```
+
 - Move out of the plutus folder an create a new folder to store the web server executable
-```
+
+```bash
 [nix-shell:path/to/plutus] > mkdir path/to/haddock-web
 [nix-shell:path/to/plutus] > cd path/to/haddock-web
 [nix-shell:path/to/haddock-web] > echo "module Main where" > main.hs
 ```
+
 - Open main.hs in your editor and copy-paste the following code. Notice that no dependencies have to be installed because we are re-using plutus' ones
+
 ```haskell
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
@@ -78,15 +83,26 @@ main = do
     putStrLn "running plutus documentation in http://localhost:8080/plutus-haddock/index.html"
     run 8080 app
 ```
-- Compile the file with 
+
+- Compile the file directly with `ghc` and run the executable (once compiled, it can run from outside the `nix-shell`)
+
+```bash
+[nix-shell:path/to/haddock-web] > ghc main.hs
+[1 of 1] Compiling Main             ( main.hs, main.o )
+Linking main ...
+[nix-shell:path/to/haddock-web] > ./main # nix-shell not necessary
+running plutus documentation in http://localhost:8080/plutus-haddock/index.html
+
+```
+- now your plutus documentation is running in the given URL with js enable. 
 
 ## How to use the documentation
 
-The plutus documentation is a big static webpage and It includes many modules not directly related with Plutus Contracts, like Plutus Core, Plutus IR or the Playground backend. 
+The plutus documentation is a big static webpage and It includes many modules not directly related with Plutus Contracts, like Plutus Core, Plutus IR or the Playground backend. If you launch haddock from a web server, you can press `s` to open the _search prompt_ which is super handy to discover unknow functions and to find the module a function is exported from.
 
 The most interesting modules for contract coding can be found at the very top of index.html page. Those are:
 
-```
+```yaml
 PlutusTx: Compiling Haskell to PLC (Plutus Core; on-chain code).
 PlutusTx.Prelude: Haskell prelude replacement compatible with PLC.
 Plutus.Contract: Writing Plutus apps (off-chain code).

--- a/book/docs/setup/buildDocumentation.md
+++ b/book/docs/setup/buildDocumentation.md
@@ -67,6 +67,10 @@ import Network.Wai.Handler.Warp (run)
 
 type Haddock = "plutus-haddock" :> Raw
 
+-- Change this port if you have a conflict with it.
+serverPort :: Int
+serverPort = 8081
+
 server :: Server.Server Haddock
 -- this path changes depending on plutus commit
 -- Using the symbolic link hasn't work for me
@@ -80,18 +84,19 @@ app = serve myApi server
 
 main :: IO ()
 main = do
-    putStrLn "running plutus documentation in http://localhost:8080/plutus-haddock/index.html"
-    run 8080 app
+    putStrLn $ "running plutus documentation in http://localhost:" <> show serverPort <> "/plutus-haddock/index.html"
+    run serverPort app
 ```
 
 - Compile the file directly with `ghc` and run the executable (once compiled, it can run from outside the `nix-shell`)
 
 ```bash
-[nix-shell:path/to/haddock-web] > ghc main.hs
+#         This is the executable's name --|
+[nix-shell:path/to/haddock-web] > ghc -o plutus-haddock main.hs
 [1 of 1] Compiling Main             ( main.hs, main.o )
-Linking main ...
-[nix-shell:path/to/haddock-web] > ./main # nix-shell not necessary
-running plutus documentation in http://localhost:8080/plutus-haddock/index.html
+Linking plutus-haddock ...
+[nix-shell:path/to/haddock-web] > ./plutus-haddock # nix-shell not necessary
+running plutus documentation in http://localhost:8081/plutus-haddock/index.html
 
 ```
 - now your plutus documentation is running in the given URL with js enable. 


### PR DESCRIPTION
Update the buildDocumentation.md to add a section for http launching. This allows the browser to run JavaScript, which I've found important in order to use haddock's search utility (very helpfull to find out modules and functions). The instructions can be helpfull  for the Community Playground which currently doesn't have built-in docs